### PR TITLE
Add ability to override workspace and build file generation per target.

### DIFF
--- a/plugin/src/main/scala/com/stripe/sbt/bazel/BazelAst.scala
+++ b/plugin/src/main/scala/com/stripe/sbt/bazel/BazelAst.scala
@@ -23,6 +23,8 @@ object BazelAst {
 
   final case class PyLoad(label: PyExpr, symbols: List[PyExpr]) extends PyExpr
 
+  final case class PyYoloString(str: String) extends PyExpr
+
   object Helpers {
     def scalaBinary(
       name: String,
@@ -134,6 +136,7 @@ object BazelAst {
             Doc.text(k) -> renderPyExpr(v)
           }
           pyCall(Doc.text(name), docArgs)
+        case PyYoloString(s) => Doc.text(s)
       }
     }
 

--- a/plugin/src/main/scala/com/stripe/sbt/bazel/package.scala
+++ b/plugin/src/main/scala/com/stripe/sbt/bazel/package.scala
@@ -2,12 +2,16 @@ package com.stripe.sbt.bazel
 
 import cats.Functor
 import cats.Show
+import com.stripe.sbt.bazel.BazelDslF._
 
 object `package` {
 
   type Algebra  [F[_], A] = F[A] =>   A
 
-  type Expr[V] = Mu[ExprF[V, ?]]
+  type Expr[V]  = Mu[ExprF[V, ?]]
+
+  // This cannot be simplified to `Mu[BazelDslF]` due to some bug with sbt. Maybe a macro issue?
+  type BazelDsl = Mu[BazelDslF[?]]
 
   implicit def showExpr[V: Show]: Show[Expr[V]] =
     Show.show(_ apply ExprF.showAlgebra)
@@ -15,5 +19,16 @@ object `package` {
   implicit val functorExpr: Functor[Expr] = new Functor[Expr] {
     def map[A, B](fa: Expr[A])(f: A => B): Expr[B] =
       fa(ExprF.mapAlgebra(f))
+  }
+
+  implicit val functorBazelDslF: Functor[BazelDslF] = new Functor[BazelDslF] {
+    override def map[A, B](fa: BazelDslF[A])(f: A => B): BazelDslF[B] = fa match {
+      case YoloString(s, n) => YoloString(s, f(n))
+      case WorkspacePrelude(n) => WorkspacePrelude(f(n))
+      case MavenBindings(n) => MavenBindings(f(n))
+      case BuildPrelude(n) => BuildPrelude(f(n))
+      case BuildTargets(n) => BuildTargets(f(n))
+      case Empty => Empty
+    }
   }
 }


### PR DESCRIPTION
Add a recursion schemes based DSL for configuring how a build/workspace file is generated. 

Here, for example, is how a workspace might be configured in a project that requires jarjar shading.

```
    bazelWorkspaceGenerate := true,
    bazelCustomWorkspace :=
      workspacePrelude +:
        mavenBindings +:
        yoloString(
          """
          |git_repository(
          |    name = "com_github_johnynek_bazel_jar_jar",
          |    commit = "4005d99473e86120c55c878309456c644202ebec",
          |    remote = "git://github.com/johnynek/bazel_jar_jar",
          |)
          |load(
          |    "@com_github_johnynek_bazel_jar_jar//:jar_jar.bzl",
          |    "jar_jar_repositories",
          |)
          |jar_jar_repositories()
          |""".stripMargin
        )
```